### PR TITLE
Remove unnecessary googleApiKey check

### DIFF
--- a/MMM-TeslaFi.js
+++ b/MMM-TeslaFi.js
@@ -42,11 +42,6 @@ Module.register('MMM-TeslaFi', {
 			wrapper.className = "dimmed light small";
 			return wrapper;
 		}
-		if (this.config.googleApiKey === "") {
-			wrapper.innerHTML = "No Google <i>api Key</i> set in config file.";
-			wrapper.className = "dimmed light small";
-			return wrapper;
-		}
 		if (!this.data) {
 			wrapper.innerHTML = "No data";
 			wrapper.className = "dimmed light small";


### PR DESCRIPTION
This googleApiKey parameter is checked, but not actually listed in the module parameters or referenced anywhere else.

Appears to have been brought in with the initial copy/paste from a template module, so is no longer needed.